### PR TITLE
Bug Fix: GitHub Autolinks Availability

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,4 @@
-import { newOctokit, commitFiles, newRepository } from "./utilities/github";
+import { newOctokit, commitFiles, newRepository, getAndStoreUserPlan } from "./utilities/github";
 import { fetchSubmissionById, fetchTopicsBySlug } from "./utilities/leetcode";
 import { EXTENSION } from "./utilities/leetcode";
 
@@ -9,6 +9,9 @@ const runMain = async () => {
   const octokit = await newOctokit();
   await newRepository(octokit);
 
+  // Get and store the user's GitHub plan
+  const plan = await getAndStoreUserPlan(octokit);
+  
   /**
    * Listen for files commit
    */
@@ -66,7 +69,9 @@ const runMain = async () => {
               );
               // Synchronize to GitHub on a topic-by-topic basis
               const { titleSlug, runtime, memory, language } = submission;
-              const message = `LC-${titleSlug} [Runtime: ${runtime}; Memory: ${memory}]`;
+              const prefix = plan === "pro" ? "LC-" : ":ballot_box_with_check: ";
+              const message = `${prefix}${titleSlug} [Runtime: ${runtime}; Memory: ${memory}]`;
+
               const changes: { path: string; content: string }[] = [];
               for (const topicSlug of topics) {
                 changes.push({

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -34,7 +34,7 @@ export const retry = async <T>(
  * @param type The type of alert to display ('leetcode' or 'github')
  * @param customMessage An optional custom message to display in the alert
  */
-export function showAlert(type: 'leetcode', customMessage?: string): void {
+export function showAlert(type: 'leetcode' | 'custom', customMessage?: string): void {
   const alertDiv = document.getElementById("alert-danger");
   const alertMessage = document.getElementById("alert-message");
 
@@ -42,12 +42,10 @@ export function showAlert(type: 'leetcode', customMessage?: string): void {
     alertDiv.style.setProperty('display', 'flex', 'important');
 
     let message;
-    if (customMessage) {
+    if (type === 'custom' && customMessage) {
       message = customMessage;
-    } else {
-      if (type === 'leetcode') {
-        message = 'Please <a href="https://leetcode.com/accounts/login/" class="alert-link" target="_blank">login</a> to LeetCode first.';
-      }
+    } else if (type === 'leetcode') {
+      message = 'Please <a href="https://leetcode.com/accounts/login/" class="alert-link" target="_blank">login</a> to LeetCode first.';
     }
 
     alertMessage.innerHTML = message;


### PR DESCRIPTION
Autolinks are only available in repositories with GitHub Pro, GitHub Team, GitHub Enterprise Cloud, and GitHub Enterprise Server. We need to consider removing or disabling the Autolink feature for users on the Basic plan, as enabling it might break the extension.